### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,7 +1,7 @@
 class ListsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
   def index
-    #@lists = List.all
+    @lists = List.order("created_at DESC")
   end
   def new
     @list = List.new

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -126,11 +126,12 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+
+    <% @lists.each do |list| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag list.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +142,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= "#{list.name}" %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= "#{list.price}" %>円<br><%= "#{list.shipping_fee.name}" %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,7 +154,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% end %>  
+
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -126,7 +126,7 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-
+  <% unless @lists.nil? %>
     <% @lists.each do |list| %>
       <li class='list'>
         <%= link_to "#" do %>
@@ -159,6 +159,7 @@
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+   <% else %>   
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -178,6 +179,7 @@
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    <% end %>  
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
# What
商品一覧機能を実装
# Why
出品された商品の一覧をトップページに表示させるため

ログイン中のユーザー画面に商品一覧が表示されている確認動画
https://gyazo.com/35aefdbd409b23aa3e0822ed475fdb2b

ログアウト状態のユーザー画面に商品一覧が表示されている確認度動画
https://gyazo.com/d119b25fe073a0c55aa59c98865e4e10