### PR TITLE
情報編集機能の実装

### DIFF
--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,7 +1,7 @@
 class ListsController < ApplicationController
-  before_action :set_list, only: [:edit, :show]
-  before_action :authenticate_user!, only: [:new, :create]
-  before_action :move_to_index, only: :edit
+  before_action :set_list, only: [:edit, :show, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :move_to_index, only: [:edit, :update]
   def index
     @lists = List.order('created_at DESC')
   end
@@ -26,7 +26,6 @@ class ListsController < ApplicationController
   end
 
   def update
-    @list = List.find(params[:id])
     if @list.update(list_params)
       redirect_to root_path
     else
@@ -46,6 +45,6 @@ class ListsController < ApplicationController
   end
 
   def move_to_index
-    redirect_to action: :index unless user_signed_in? && current_user == @list.user
+    redirect_to action: :index unless current_user == @list.user
   end
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,5 +1,7 @@
 class ListsController < ApplicationController
+  before_action :set_list, only: [:edit, :show]
   before_action :authenticate_user!, only: [:new, :create]
+  before_action :move_to_index, only: :edit
   def index
     @lists = List.order('created_at DESC')
   end
@@ -18,7 +20,18 @@ class ListsController < ApplicationController
   end
 
   def show
+  end
+
+  def edit
+  end
+
+  def update
     @list = List.find(params[:id])
+    if @list.update(list_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
   end
 
   private
@@ -26,5 +39,13 @@ class ListsController < ApplicationController
   def list_params
     params.require(:list).permit(:image, :name, :detail, :category_id, :status_id, :shipping_fee_id, :location_id,
                                  :shipping_date_id, :price).merge(user_id: current_user.id)
+  end
+
+  def set_list
+    @list = List.find(params[:id])
+  end
+
+  def move_to_index
+    redirect_to action: :index unless user_signed_in? && current_user == @list.user
   end
 end

--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @list, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :detail, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_id, ShippingFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:location_id, Location.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>


### PR DESCRIPTION
# What
商品情報編集機能の実装

# Why
商品の情報を出品後に編集できるようにするため

必要な情報を入力すると商品情報を変更できる確認動画
https://gyazo.com/24cffc568c37d8132a5a1064c2fbb6a3

何も編集せずに更新しても画像なしの商品にならない確認動画
https://gyazo.com/cd75d26b29e04990796b2ae068ae12e6

ログイン状態の出品者だけが商品情報編集ページに遷移できる確認動画
https://gyazo.com/d953d9b79f2e8d6828bdd0de3d125655

ログイン状態の出品者以のユーザーはurlを直接入力するとトップページに遷移される確認動画
https://gyazo.com/910fa465d33b8988c89a62b009628d70

ログアウト状態のユーザーはurlを直接入力するとトップページに遷移される確認動画
https://gyazo.com/f22cf50673ea409dfb8403b4f91cc428

商品出品時とほぼ同じ状態で商品情報編集ページが作成されている確認動画
https://gyazo.com/438facb906eee6b3548e54f55194908f

すでに登録されている商品情報は編集ページが開いた時点で表示されている確認動画
https://gyazo.com/bc2fccd21addd9911fc967d1040d3bc5

商品情報が空白だとエラーが出力される確認動画
https://gyazo.com/08c70519bf61e6795ee3b11e7a60c828

適切な値が入力されてないとエラーが出力される確認動画
https://gyazo.com/eb1fa026e279d607f4d88a0528802fb6